### PR TITLE
Bugfix/fail health on missing routes

### DIFF
--- a/microplay-lib/app/com/pb/microplay/configuration/RoutesDelegator.scala
+++ b/microplay-lib/app/com/pb/microplay/configuration/RoutesDelegator.scala
@@ -37,7 +37,7 @@ class RoutesDelegator @Inject() (injector: Injector, env: Environment, conf: App
   }
   catch {
     case x:Throwable =>
-      logger.warn("can't find default generated Routes from `routes` file",x)
+      logger.info("can't find default generated Routes from `routes` file. "+x.getMessage)
       if(conf.getOptional[Boolean]("micro.assert-default-routes").getOrElse(true)) {
         throw new Exception("can't load default generated Routes from `routes` file",x)
       }

--- a/microplay-lib/build.sbt
+++ b/microplay-lib/build.sbt
@@ -2,7 +2,7 @@ import java.time.{ZoneOffset, ZonedDateTime}
 
 name := "microplay"
 organization := "com.pb"
-version := sys.env.getOrElse("VERSION", "3.26.0-SNAPSHOT")
+version := sys.env.getOrElse("VERSION", "3.26.1-SNAPSHOT")
 scalaVersion := "2.12.8"
 bintrayRepository := "PB_Maven"
 bintrayPackage := "microplay"

--- a/microplay-lib/conf/application.conf
+++ b/microplay-lib/conf/application.conf
@@ -91,6 +91,7 @@ micro {
     response-body.max-bytes = 100000
   }
   env.message="default env"
+  assert-default-routes = true # when true - dont use microplay routing context (in file microplay.routes) - in case the default routes file is missing or failed to load. Main motivation is to not serve health check endpoint when routing context failed. should be turned off in case default routes file is not used at all.
 }
 //logger.reactivemongo=TRACE
 

--- a/microplay-lib/conf/microplay.routes
+++ b/microplay-lib/conf/microplay.routes
@@ -1,4 +1,3 @@
-
 # Routes
 # This file defines all application routes (Higher priority routes first)
 # ~~~~

--- a/microplay-lib/it/com/pb/microplay/controllers/HealthCheckControllerTest.scala
+++ b/microplay-lib/it/com/pb/microplay/controllers/HealthCheckControllerTest.scala
@@ -18,19 +18,18 @@ import play.api.test._
 class HealthCheckControllerTest extends PlayFakeAppSpecification{
   sequential
   "HealthCheckController" should {
-//    "health end point" in new WithApplication(getFakeApp) {
-    "health end point" in new WithApplication {
+    "health end point" in new WithApplication(getFakeApp) {
       val Some(result) = route(app, FakeRequest(GET, "/health"))
       status(result) mustEqual OK
       contentAsString(result) mustEqual "I'm Ok. Thanks for checking."
     }
 
-    "env end point" in new WithApplication {
+    "env end point" in new WithApplication(getFakeApp)  {
       val Some(result) = route(app, FakeRequest(GET, "/env"))
       status(result) mustEqual OK
-      contentAsString(result) mustEqual "default env"
+      contentAsString(result) mustEqual "this is test env"
     }
-    "build info status end point" in new WithApplication {
+    "build info status end point" in new WithApplication(getFakeApp)  {
       val Some(result) = route(app, FakeRequest(GET, "/status"))
       status(result) mustEqual OK
       contentAsString(result) must contain("\"buildTime\"")

--- a/microplay-lib/it/resources/conf/application-test.conf
+++ b/microplay-lib/it/resources/conf/application-test.conf
@@ -1,4 +1,4 @@
-include "application.conf"
+include "/application.conf"
 
 micro{
   is-dev-env=true

--- a/microplay-lib/it/resources/conf/application-test.conf
+++ b/microplay-lib/it/resources/conf/application-test.conf
@@ -3,5 +3,6 @@ include "application.conf"
 micro{
   is-dev-env=true
   env.message="this is test env"
+  assert-default-routes = false
 }
 

--- a/microplay-lib/test/resources/conf/application-test.conf
+++ b/microplay-lib/test/resources/conf/application-test.conf
@@ -1,6 +1,0 @@
-include "application.conf"
-micro{
-  is-dev-env=true
-  env.message="this is test env"
-  assert-default-routes = false
-}

--- a/microplay-lib/test/resources/conf/application-test.conf
+++ b/microplay-lib/test/resources/conf/application-test.conf
@@ -2,4 +2,5 @@ include "application.conf"
 micro{
   is-dev-env=true
   env.message="this is test env"
+  assert-default-routes = false
 }


### PR DESCRIPTION
Add a new configuration key `micro.assert-default-routes`. If default routes file is missing and configuration key `micro.assert-default-routes` is `true` (the default) - then fail the routing context initialization. Main motivation is to disable the health endpoints if default routing context failed to load